### PR TITLE
[wasm] Move some reftypes opcodes to the right group;

### DIFF
--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -349,6 +349,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _heap: ir::Heap,
         _val: ir::Value,
     ) -> WasmResult<ir::Value> {
+        // Don't do anything and return the failure sentinel value.
         Ok(pos.ins().iconst(I32, -1))
     }
 
@@ -358,6 +359,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _index: MemoryIndex,
         _heap: ir::Heap,
     ) -> WasmResult<ir::Value> {
+        // Don't do anything and return the failure sentinel value.
         Ok(pos.ins().iconst(I32, -1))
     }
 }


### PR DESCRIPTION
Also adds blank lines between opcode groups.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so and/or ping
  `bnjbvr`. The list of suggested reviewers on the right can help you.

<!-- Please ensure all communication adheres to the [code of
conduct](https://github.com/CraneStation/cranelift/blob/master/CODE_OF_CONDUCT.md). -->
